### PR TITLE
Integrate Strapi SDK via CDN

### DIFF
--- a/assets/js/cms-topbar-ids.js
+++ b/assets/js/cms-topbar-ids.js
@@ -1,7 +1,14 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@strapi/sdk-js/+esm';
+
 // ===== Config =====
 const STRAPI_URL   = window.STRAPI_URL  || 'http://localhost:1337';
 const STRAPI_TOKEN = window.STRAPI_TOKEN || '';
-const authHeaders  = STRAPI_TOKEN ? { Authorization: `Bearer ${STRAPI_TOKEN}` } : {};
+
+const client = createClient({
+  url: STRAPI_URL,
+  prefix: '/api',
+  token: STRAPI_TOKEN,
+});
 
 // ===== Helpers =====
 function withTimeout(promise, ms = 12000, message = `Request timed out after ${ms} ms`) {
@@ -12,11 +19,8 @@ function withTimeout(promise, ms = 12000, message = `Request timed out after ${m
   });
 }
 
-async function getJSON(path) {
-  const url = `${STRAPI_URL}${path}`;
-  const res = await fetch(url, { headers: { ...authHeaders } });
-  if (!res.ok) throw new Error(`HTTP ${res.status} @ ${url}`);
-  return res.json();
+async function getJSON(path, params = {}) {
+  return client.http.get(path, { searchParams: params }).json();
 }
 
 // Normalize phone to tel: href
@@ -53,7 +57,7 @@ function firstNonEmpty(obj, candidates) {
 async function renderTopBarIDs() {
     try {
       console.time('site-setting');
-      const resp = await withTimeout(getJSON('/api/site-setting?populate=*'), 12000);
+      const resp = await withTimeout(getJSON('site-setting', { populate: '*' }), 12000);
       console.timeEnd('site-setting');
       console.debug('[TopBar] raw response:', resp);
   

--- a/index.html
+++ b/index.html
@@ -447,7 +447,7 @@ https://templatemo.com/tm-559-zay-shop
         // OPCIONAL (recomendado en prod): token de lectura
         window.STRAPI_TOKEN = '9769895d71ebbee93a531e963ed448f6fa636af9bf48e5c9dbdc95f833568c55cb5332718d7728886568461993c6bbf197292361eb21d077735b293eb58dbd659ddddb3dd2989919f5bb510798772907b67879288abaf6318591c28d9f736cbb249407f1c75b2a24f0206b05274b4d3d0a215a888617d593356c301276c3c25a'; // pégalo aquí si vas a usar API Token
     </script>
-    <script src="assets/js/cms-topbar-ids.js" defer></script>
+    <script type="module" src="assets/js/cms-topbar-ids.js"></script>
       
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hoja_web_frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests defined\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@strapi/sdk-js": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- load Strapi SDK from CDN and fetch site settings with it
- mark cms script as ES module and create client helper
- declare @strapi/sdk-js dependency for future installs

## Testing
- `npm test`
- `npm install @strapi/sdk-js` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68bf3616068883329e4d005dbb8192b9