### PR TITLE
Fix Strapi SDK import path for topbar

### DIFF
--- a/assets/js/cms-topbar-ids.js
+++ b/assets/js/cms-topbar-ids.js
@@ -1,4 +1,9 @@
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@strapi/sdk-js/+esm';
+// Use the ESM build of the Strapi SDK. The previous "+esm" URL
+// returned a wrapper that didn't expose the expected named exports,
+// causing runtime failures when importing `createClient` in the
+// browser. Switching to the `?module` parameter delivers the proper
+// module build with the `createClient` export.
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@strapi/sdk-js@latest?module';
 
 // ===== Config =====
 const STRAPI_URL   = window.STRAPI_URL  || 'http://localhost:1337';


### PR DESCRIPTION
## Summary
- use the proper ESM CDN build of `@strapi/sdk-js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf38f851788332b2bd33eee5a56b19