### PR TITLE
fix: load Strapi SDK via jsDelivr ESM build

### DIFF
--- a/assets/js/cms-topbar-ids.js
+++ b/assets/js/cms-topbar-ids.js
@@ -1,9 +1,8 @@
-// Use the ESM build of the Strapi SDK. The previous "+esm" URL
-// returned a wrapper that didn't expose the expected named exports,
-// causing runtime failures when importing `createClient` in the
-// browser. Switching to the `?module` parameter delivers the proper
-// module build with the `createClient` export.
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@strapi/sdk-js@latest?module';
+// Load the Strapi SDK via jsDelivr using the `+esm` build, which
+// exposes the SDK methods on the default export. Destructure
+// `createClient` from that object for use below.
+import StrapiSDK from 'https://cdn.jsdelivr.net/npm/@strapi/sdk-js@latest/+esm';
+const { createClient } = StrapiSDK;
 
 // ===== Config =====
 const STRAPI_URL   = window.STRAPI_URL  || 'http://localhost:1337';


### PR DESCRIPTION
## Summary
- use jsDelivr `+esm` build of Strapi SDK and destructure `createClient`

## Testing
- `npm test`
- `node --experimental-network-imports -e "import('https://cdn.jsdelivr.net/npm/@strapi/sdk-js@latest/+esm')"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3bd9a44083329f1d7555dcc0ab63